### PR TITLE
Issue #93: Remove stale VERSION migration entry from configScript

### DIFF
--- a/src-db/database/configScript.xml
+++ b/src-db/database/configScript.xml
@@ -309,10 +309,6 @@
       <oldValue/>
       <newValue><![CDATA[#008000]]></newValue>
     </columnDataChange>
-    <columnDataChange tablename="AD_MODULE" columnname="VERSION" pkRow="27A3573BAAB24816AE019290FFBF977C">
-      <oldValue><![CDATA[0.8.0]]></oldValue>
-      <newValue><![CDATA[0.8.1]]></newValue>
-    </columnDataChange>
     <columnDataChange tablename="OBUIAPP_PROCESS" columnname="EM_ETMETA_ONLOAD" pkRow="8DF818E471394C01A6546A4AB7F5E529">
       <oldValue/>
       <newValue><![CDATA[async (process, context) => {


### PR DESCRIPTION
## Summary

- Removes a stale `columnDataChange` entry from `configScript.xml` that was updating `AD_MODULE.VERSION` from `0.8.0` to `0.8.1`
- This entry belongs to a previous release cycle and should not be present in version `1.0.0` of the artifact
- Its presence caused a version conflict error during Etendo's `install` task when the DB already had version `0.8.1`

## Test plan

- [ ] Run `install` task with `metadata.template:1.0.0` and verify no version conflict error is thrown
- [ ] Run `update.database` and verify it completes without issues
- [ ] Verify `AD_MODULE.VERSION` for `metadata.template` is correctly set by `AD_MODULE.xml` sourcedata

Fixes etendosoftware/com.etendoerp.platform.extensions#93

ETP-3622