### PR TITLE
Issue #93: Remove stale VERSION migration entry from configScript

### DIFF
--- a/src-db/database/configScript.xml
+++ b/src-db/database/configScript.xml
@@ -309,10 +309,6 @@
       <oldValue/>
       <newValue><![CDATA[#008000]]></newValue>
     </columnDataChange>
-    <columnDataChange tablename="AD_MODULE" columnname="VERSION" pkRow="27A3573BAAB24816AE019290FFBF977C">
-      <oldValue><![CDATA[0.8.0]]></oldValue>
-      <newValue><![CDATA[0.8.1]]></newValue>
-    </columnDataChange>
     <columnDataChange tablename="OBUIAPP_PROCESS" columnname="EM_ETMETA_ONLOAD" pkRow="8DF818E471394C01A6546A4AB7F5E529">
       <oldValue/>
       <newValue><![CDATA[async (process, context) => {


### PR DESCRIPTION
## Summary

- Backport to `release/25.4` of the fix from #10
- Removes a stale `columnDataChange` entry from `configScript.xml` that was updating `AD_MODULE.VERSION` from `0.8.0` to `0.8.1`
- Its presence caused a version conflict error during Etendo's `install` task when the DB already had version `0.8.1`

## Test plan

- [ ] Run `install` task with the fixed artifact and verify no version conflict error is thrown
- [ ] Run `update.database` and verify it completes without issues

Backport of #10
Fixes etendosoftware/com.etendoerp.platform.extensions#93

ETP-3622